### PR TITLE
Update hook name for Vue2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var windowsill = require('windowsill');
 var resizer = windowsill.resizer;
 
 module.exports = {
-  ready: function() {
+  mounted: function() {
     windowsill.enable('resizer');
     resizer.addListener(this._resize);
     this._resize();


### PR DESCRIPTION
`created` hook event still exists but has a different behaviour than in Vue 1.x.

I believe we want to get the `resize` only after `this.$el` has been mounted. This pull request will break Vue 1.x compatibility but will correct the behaviour on Vue 2.x